### PR TITLE
Feat/add product history card

### DIFF
--- a/app/UserArea/page.tsx
+++ b/app/UserArea/page.tsx
@@ -5,19 +5,34 @@ import { UserAreaInterface } from "@/components/UserAreaInterface";
 import { useAuth } from "@/context/AuthContext/AuthContext";
 import { useUser } from "@/context/UserContext/UserContext";
 import { redirect } from "next/navigation";
+import { useMemo } from "react";
 
 const UserArea = () => {
   const { user, logout } = useAuth();
-  const { data } = useUser();
+  const { data, loading } = useUser();
+
+  if (!user) {
+    redirect("/");
+  }
+
+  const history = useMemo(
+    () => data?.historyPreview ?? [],
+    [data?.historyPreview],
+  );
+
+  const spins = data?.quota.spins;
 
   return (
     <>
       <Header user={user} />
-      {user ? (
-        <UserAreaInterface data={data} user={user} logout={logout} />
-      ) : (
-        redirect("/")
-      )}
+      <UserAreaInterface
+        historyPreview={history}
+        loading={loading}
+        spins={spins}
+        data={data}
+        user={user}
+        logout={logout}
+      />
     </>
   );
 };

--- a/components/Slots/Slots.tsx
+++ b/components/Slots/Slots.tsx
@@ -16,7 +16,7 @@ const Slots = () => {
   const [spinning, setSpinning] = useState(false);
   const [selectedProducts, setSelectedProducts] = useState<Product[]>([]);
   const { authorizedFetch } = useAuth();
-  const { consumeSpin, loading } = useUser();
+  const { loading, optimisticSpin } = useUser();
 
   const renderDeployAddress = process.env.NEXT_PUBLIC_API_URL;
 
@@ -36,9 +36,17 @@ const Slots = () => {
         throw new Error("Spin failed");
       }
 
+      const spinItem = {
+        id: data.id,
+        createdAt: data.createdAt ?? new Date().toISOString(),
+        products: data.products ?? [],
+        quotaBefore: data.quota.before,
+        quotaAfter: data.quota.after,
+      };
+
       // 🎯 Backend is the authority
       setSelectedProducts(data.products ?? []);
-      consumeSpin(data.quota);
+      optimisticSpin(spinItem, data.quota);
     } catch (err) {
       console.error("Spin error:", err);
     } finally {

--- a/components/Slots/types/index.ts
+++ b/components/Slots/types/index.ts
@@ -7,7 +7,7 @@ interface Product {
   price: string;
   discount: string;
   discountedPrice: string;
-  tier?: Tier;
+  tier: Tier;
   store: string;
   campaign: CampaignProps;
 }

--- a/components/UserAreaInterface/DailyQuota/DailyQuota.tsx
+++ b/components/UserAreaInterface/DailyQuota/DailyQuota.tsx
@@ -1,18 +1,17 @@
-// components/DailyQuota.tsx
 "use client";
-import { useUser } from "@/context/UserContext/UserContext";
 import { RemainingDisplay } from "./components/RemainingDisplay";
 import { DailyOffersHistory } from "./components/DailyOffersHistory";
 import { OutOfSpinsInterface } from "./components/OutOfSpinsInterface";
+import { FC } from "react";
+import { DailyQuotaProps } from "../types";
 
-const DailyQuota = () => {
-  const { data, loading } = useUser();
-
-  const historyPreview = data?.historyPreview;
-
-  console.log("DailyQuotaData", data?.historyPreview);
-
-  if (loading || !data) {
+const DailyQuota: FC<DailyQuotaProps> = ({
+  spins,
+  historyPreview,
+  loading,
+  data,
+}) => {
+  if (loading || !historyPreview) {
     return (
       <div className="flex flex-col space-y-2 bg-white/90 backdrop-blur rounded-lg shadow-md p-4">
         <OutOfSpinsInterface />
@@ -21,9 +20,9 @@ const DailyQuota = () => {
   }
 
   return (
-    <div className="flex flex-col space-y-2 bg-white/90 backdrop-blur rounded-lg shadow-md p-4">
-      <RemainingDisplay data={data} />
-      <DailyOffersHistory historyPreview={historyPreview} />
+    <div className="flex flex-col space-y-2 bg-white/90 backdrop-blur rounded-lg shadow-md p-4 ">
+      <RemainingDisplay spins={spins} />
+      <DailyOffersHistory data={data} historyPreview={historyPreview} />
     </div>
   );
 };

--- a/components/UserAreaInterface/DailyQuota/components/DailyOffersHistory/DailyOffersHistory.tsx
+++ b/components/UserAreaInterface/DailyQuota/components/DailyOffersHistory/DailyOffersHistory.tsx
@@ -1,42 +1,29 @@
-import { Product } from "@/components/Slots/types";
+"use client";
+
 import { UserAreaSectionBackground } from "@/components/UserAreaInterface/UserAreaSectionBackground";
-import { redirect } from "next/navigation";
+import { useRouter } from "next/navigation";
+import { SpinHistoryItem, UserState } from "@/context/UserContext/types";
+import { ProductHistoryCard } from "./components/ProductHistoryCard";
 
 const DailyOffersHistory = ({
+  data,
   historyPreview,
 }: {
-  historyPreview: unknown;
+  data: UserState | null;
+  historyPreview: SpinHistoryItem[] | SpinHistoryItem | null | undefined;
 }) => {
-  const offers = Array.isArray(historyPreview)
+  const router = useRouter();
+
+  // normalize safely
+  const history: SpinHistoryItem[] = Array.isArray(historyPreview)
     ? historyPreview
-    : [historyPreview];
+    : historyPreview
+      ? [historyPreview]
+      : [];
 
-  const allProducts = offers.flatMap((offer) => offer?.products ?? []);
+  const isEmpty = history.length === 0;
 
-  if (allProducts.length === 0) {
-    return (
-      <UserAreaSectionBackground>
-        <h3 className="text-sm font-semibold text-slate-800 mb-2">
-          Histórico de Ofertas
-        </h3>
-        <hr className="border-t border-slate-300 mb-4" />
-        <div className="text-center mb-2 space-y-2 flex flex-col max-w-sm mx-auto">
-          <div className="my-4">
-            <span>Sem histórico por enquanto...</span>
-          </div>
-          <button
-            className="
-      cursor-pointer  py-2 drop-shadow-xl text-shadow-2xs
-       bg-green-400 hover:bg-green-200 transition
-      text-slate-50 rounded-xs disabled:bg-slate-400 pb-2 font-semibold"
-            onClick={() => redirect("/")}
-          >
-            Começe a Jogar
-          </button>
-        </div>
-      </UserAreaSectionBackground>
-    );
-  }
+  console.log("DailyOffersHistory", history);
 
   return (
     <UserAreaSectionBackground>
@@ -44,11 +31,33 @@ const DailyOffersHistory = ({
         Histórico de Ofertas
       </h3>
       <hr className="border-t border-slate-300 mb-4" />
+      <div className="h-75 overflow-scroll   [scrollbar-width:none]">
+        {isEmpty ? (
+          <div className="text-center mb-2 space-y-2 flex flex-col max-w-sm mx-auto">
+            <div className="my-4">
+              <span>Sem histórico por enquanto...</span>
+            </div>
 
-      <div>
-        {allProducts.map((product: Product) => (
-          <div key={product.id}>{product.name}</div>
-        ))}
+            <button
+              className="cursor-pointer py-2 drop-shadow-xl text-shadow-2xs
+              bg-green-400 hover:bg-green-200 transition
+              text-slate-50 rounded-xs disabled:bg-slate-400 pb-2 font-semibold"
+              onClick={() => router.push("/")}
+            >
+              Começe a Jogar
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {history.map((spin) => (
+              <ProductHistoryCard
+                key={spin.createdAt}
+                spin={spin}
+                data={data}
+              />
+            ))}
+          </div>
+        )}
       </div>
     </UserAreaSectionBackground>
   );

--- a/components/UserAreaInterface/DailyQuota/components/DailyOffersHistory/components/HistoryProductItem/HistoryProductItem.tsx
+++ b/components/UserAreaInterface/DailyQuota/components/DailyOffersHistory/components/HistoryProductItem/HistoryProductItem.tsx
@@ -1,0 +1,43 @@
+import { formatPriceBRL } from "@/components/Slots/components/SlotsGame/components/ProductCard/utils";
+import { Product } from "@/components/Slots/types";
+
+export default function HistoryProductItem({ product }: { product: Product }) {
+  const tierStyles: Record<string, string> = {
+    common: "bg-slate-100 text-slate-700",
+    rare: "bg-indigo-100 text-indigo-700",
+    jackpot: "bg-amber-100 text-amber-700",
+  };
+
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-md bg-white px-3 py-2">
+      {/* Left */}
+      <div className="flex flex-col min-w-0">
+        <a
+          href={product.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm font-medium text-slate-900 hover:underline truncate"
+        >
+          {product.name}
+        </a>
+
+        <span className="text-xs text-slate-500">{product.store}</span>
+      </div>
+
+      {/* Right */}
+      <div className="flex items-center gap-2 shrink-0">
+        <span className="text-sm font-semibold text-slate-800">
+          {formatPriceBRL(product.price)}
+        </span>
+
+        <span
+          className={`text-[10px] px-2 py-0.5 rounded-full font-semibold ${
+            tierStyles[product.tier] ?? "bg-slate-100 text-slate-700"
+          }`}
+        >
+          {product.tier}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/components/UserAreaInterface/DailyQuota/components/DailyOffersHistory/components/HistoryProductItem/index.ts
+++ b/components/UserAreaInterface/DailyQuota/components/DailyOffersHistory/components/HistoryProductItem/index.ts
@@ -1,0 +1,1 @@
+export { default as HistoryProductItem } from "./HistoryProductItem";

--- a/components/UserAreaInterface/DailyQuota/components/DailyOffersHistory/components/ProductHistoryCard/ProductHistoryCard.tsx
+++ b/components/UserAreaInterface/DailyQuota/components/DailyOffersHistory/components/ProductHistoryCard/ProductHistoryCard.tsx
@@ -1,0 +1,54 @@
+import { SpinHistoryItem, UserState } from "@/context/UserContext/types";
+import { HistoryProductItem } from "../HistoryProductItem";
+
+const ProductHistoryCard = ({
+  spin,
+  data,
+}: {
+  spin: SpinHistoryItem;
+  data: UserState | null;
+}) => {
+  const date = new Date(spin.createdAt);
+
+  const before =
+    spin.quotaBefore ?? (data ? data.quota.spins.used - 1 : spin.quotaBefore);
+
+  const after = spin.quotaAfter ?? data?.quota.spins.used;
+
+  const borderTierStyles: Record<string, string> = {
+    common: "border-slate-400 ",
+    rare: "border-indigo-300 ",
+    jackpot: "border-amber-300",
+  };
+
+  return (
+    <div className="rounded-md  bg-slate-200 p-3  mx-2">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-xs font-semibold text-slate-700">
+          {date.toLocaleString()}
+        </span>
+
+        {before !== undefined && after !== undefined && (
+          <span className="text-xs text-slate-500">
+            {before} → {after}
+          </span>
+        )}
+      </div>
+
+      {/* Products */}
+      <div className="space-y-1">
+        {spin.products.map((product) => (
+          <div
+            key={product.id}
+            className={`text-sm text-slate-800 ${borderTierStyles[product.tier]} border rounded-md `}
+          >
+            <HistoryProductItem product={product} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ProductHistoryCard;

--- a/components/UserAreaInterface/DailyQuota/components/DailyOffersHistory/components/ProductHistoryCard/index.ts
+++ b/components/UserAreaInterface/DailyQuota/components/DailyOffersHistory/components/ProductHistoryCard/index.ts
@@ -1,0 +1,1 @@
+export { default as ProductHistoryCard } from "./ProductHistoryCard";

--- a/components/UserAreaInterface/DailyQuota/components/RemainingDisplay/RemainingDisplay.tsx
+++ b/components/UserAreaInterface/DailyQuota/components/RemainingDisplay/RemainingDisplay.tsx
@@ -1,12 +1,14 @@
 import { UserAreaSectionBackground } from "@/components/UserAreaInterface/UserAreaSectionBackground";
-import { UserState } from "@/context/UserContext/types";
+import { SpinQuota } from "@/context/UserContext/types";
 
-const RemainingDisplay = ({ data }: { data: UserState | null }) => {
-  if (!data) return;
-  const remaining = data.quota.spins.remaining;
-  const dailyLimit = data.quota.spins.limit;
+const RemainingDisplay = ({ spins }: { spins: SpinQuota | undefined }) => {
+  const remaining = spins?.remaining;
+  const dailyLimit = spins?.limit;
 
-  const progress = dailyLimit > 0 ? (remaining / dailyLimit) * 100 : 0;
+  const progress =
+    dailyLimit && remaining && dailyLimit > 0
+      ? (remaining / dailyLimit) * 100
+      : 0;
 
   const barColor =
     progress > 60

--- a/components/UserAreaInterface/UserAreaInterface.tsx
+++ b/components/UserAreaInterface/UserAreaInterface.tsx
@@ -1,19 +1,16 @@
-import { User } from "firebase/auth";
-import { BannerPromo } from "../BannerPromo";
 import { DailyQuota } from "./DailyQuota";
 import { Rewards } from "./Rewards";
 import { UserStats } from "./UserStats";
 import { UserCard } from "./UserCard";
-import { UserState } from "@/context/UserContext/types";
+import { UserAreaInterfaceProps } from "./types";
 
-const UserAreaInterface = ({
+const UserAreaInterface: React.FC<UserAreaInterfaceProps> = ({
   user,
   data,
   logout,
-}: {
-  user: User | null;
-  data: UserState | null;
-  logout: () => void;
+  historyPreview,
+  spins,
+  loading,
 }) => {
   return (
     <div className="relative min-h-screen font-sans overflow-hidden">
@@ -22,7 +19,12 @@ const UserAreaInterface = ({
         {user && (
           <div className="w-full  grid gap-4 mb-6">
             <UserCard user={user} logout={logout} />
-            <DailyQuota />
+            <DailyQuota
+              historyPreview={historyPreview}
+              spins={spins}
+              loading={loading}
+              data={data}
+            />
             <UserStats data={data} />
             <Rewards />
           </div>

--- a/components/UserAreaInterface/UserCard/UserCard.tsx
+++ b/components/UserAreaInterface/UserCard/UserCard.tsx
@@ -1,13 +1,8 @@
-import { User } from "firebase/auth";
 import { UserOptions } from "./components/UserOptions";
+import { FC } from "react";
+import { UserCardProps } from "../types";
 
-const UserCard = ({
-  user,
-  logout,
-}: {
-  user: User | null;
-  logout: () => void;
-}) => {
+const UserCard: FC<UserCardProps> = ({ user, logout }) => {
   return (
     <div className="w-full bg-white/90 backdrop-blur rounded-lg shadow-md p-4 ">
       {user && (

--- a/components/UserAreaInterface/UserCard/components/UserOptions/UserOptions.tsx
+++ b/components/UserAreaInterface/UserCard/components/UserOptions/UserOptions.tsx
@@ -1,14 +1,9 @@
+import { UserCardProps } from "@/components/UserAreaInterface/types";
 import { UserAreaSectionBackground } from "@/components/UserAreaInterface/UserAreaSectionBackground";
-import { User } from "firebase/auth";
+import { FC } from "react";
 import { FaPowerOff } from "react-icons/fa";
 
-const UserOptions = ({
-  user,
-  logout,
-}: {
-  user: User | null;
-  logout: () => void;
-}) => {
+const UserOptions: FC<UserCardProps> = ({ user, logout }) => {
   return (
     <UserAreaSectionBackground>
       <div className="flex justify-between gap-3">

--- a/components/UserAreaInterface/UserStats/UserStats.tsx
+++ b/components/UserAreaInterface/UserStats/UserStats.tsx
@@ -11,6 +11,7 @@ import { UserState } from "@/context/UserContext/types";
 const UserStats = ({ data }: { data: UserState | null }) => {
   const accountStats = data?.stats;
   const totalReward = data?.stats.totalRewards;
+  const subStatus = data?.user.subscription;
   return (
     <div className="bg-white/90 backdrop-blur rounded-lg shadow-md p-4">
       <div>
@@ -20,7 +21,7 @@ const UserStats = ({ data }: { data: UserState | null }) => {
         <hr className="border-t border-slate-300 my-2" />
       </div>
       <div className=" flex flex-col space-y-2">
-        <SubscriptionStatus data={data} />
+        <SubscriptionStatus subStatus={subStatus} />
         <AccountRewardHistory total={totalReward} />
         <AccountSpinHistory stats={accountStats} />
         <TrophiesAcquired />

--- a/components/UserAreaInterface/UserStats/components/SubscriptionStatus/SubscriptionStatus.tsx
+++ b/components/UserAreaInterface/UserStats/components/SubscriptionStatus/SubscriptionStatus.tsx
@@ -1,16 +1,18 @@
 import { UserAreaSectionBackground } from "@/components/UserAreaInterface/UserAreaSectionBackground";
-import { UserState } from "@/context/UserContext/types";
 import { SubscriptionTag } from "./SubscriptionTag";
 
-const SubscriptionStatus = ({ data }: { data: UserState | null }) => {
-  const subscriptionStatus = data?.user.subscription;
+const SubscriptionStatus = ({
+  subStatus,
+}: {
+  subStatus: string | undefined;
+}) => {
   return (
     <UserAreaSectionBackground>
       <span className="text-xs font-semibold text-slate-600">
         Assinatura Ativa :
       </span>
       <div>
-        <SubscriptionTag subStatus={subscriptionStatus} />
+        <SubscriptionTag subStatus={subStatus} />
       </div>
     </UserAreaSectionBackground>
   );

--- a/components/UserAreaInterface/types/index.ts
+++ b/components/UserAreaInterface/types/index.ts
@@ -1,0 +1,29 @@
+import {
+  SpinHistoryItem,
+  SpinQuota,
+  UserState,
+} from "@/context/UserContext/types";
+import { User } from "firebase/auth";
+
+interface UserAreaInterfaceProps {
+  user: User | null;
+  data: UserState | null;
+  logout: () => void;
+  historyPreview: SpinHistoryItem[] | undefined;
+  spins: SpinQuota | undefined;
+  loading: boolean;
+}
+
+type UserCardProps = {
+  user: User | null;
+  logout: () => void;
+};
+
+type DailyQuotaProps = {
+  data: UserState | null;
+  spins: SpinQuota | undefined;
+  historyPreview: SpinHistoryItem[] | undefined;
+  loading: boolean;
+};
+
+export type { UserAreaInterfaceProps, UserCardProps, DailyQuotaProps };

--- a/context/UserContext/types/index.ts
+++ b/context/UserContext/types/index.ts
@@ -29,8 +29,18 @@ type UserState = {
   };
   stats: UserStats;
   rewards: unknown[];
-  historyPreview: Product[] | [];
+  historyPreview: SpinHistoryItem[];
 };
+
+interface SpinHistoryItem {
+  id: string;
+  createdAt: string;
+  ip?: string;
+  userAgent?: string;
+  quotaBefore: number;
+  quotaAfter: number;
+  products: Product[];
+}
 
 interface UserContextProps {
   data: UserState | null;
@@ -38,6 +48,14 @@ interface UserContextProps {
   error: string | null;
   refresh: () => Promise<void>;
   consumeSpin: (quota: SpinQuota) => void;
+  optimisticSpin: (spin: SpinHistoryItem, quota: SpinQuota) => void;
 }
 
-export type { UserContextProps, UserState, BackendUser, SpinQuota, UserStats };
+export type {
+  UserContextProps,
+  UserState,
+  BackendUser,
+  SpinQuota,
+  UserStats,
+  SpinHistoryItem,
+};


### PR DESCRIPTION
## Description

This PR continues the effort to improve maintainability across components and better structure the flows in preparation for upcoming features.

It enhances the `UserContext` spin logic, exposing spin-related data such as `SpinHistoryItem` and `SpinQuota`, along with stronger and more consistent typing.

There is also a broader restructuring of the UserAreaInterface, making it more comprehensive and maintainable. The interface now has its own type definitions, and the new components `<HistoryProductItem />` and `<ProductHistoryCard />` were introduced. UserArea has been updated to reflect this new structure.

`Slots` received a small but important update: it now uses optimisticSpin. Additionally, the optional modifier was removed from the Product.tier type, since tier is provided by the SOT (the backend) and will always be present in the product payload.